### PR TITLE
Upload widget settings on toter upload

### DIFF
--- a/toter.js
+++ b/toter.js
@@ -81,7 +81,12 @@ const commands = {
     ),
     submit: require('./commands/submit').bind({ logger }, api, config, region),
     update: require('./commands/update').bind({ logger }, api, config, region),
-    upload: require('./commands/upload').bind({ logger }, api, config, region)
+    upload: require('./commands/upload').bind(
+        { logger },
+        api,
+        defaults.configPath,
+        region
+    )
 }
 
 // run the command


### PR DESCRIPTION
Basically on toter upload it should support widget schema update so that we can pass in an optional schema from which to generate data from.