### PR TITLE
Payload and API changes.

### DIFF
--- a/commands/setup.js
+++ b/commands/setup.js
@@ -48,7 +48,10 @@ function setup(api, config, region, defaults) {
                 .then(res => uploadWidget(this.logger, api, res, defaults))
                 .then(res => {
                     config[region].app_json = res.app
+                    config[region].app_json.distribution = ['all']
+
                     config[region].widget_json = stripFields(res.widget)
+                    config[region].widget_json.use_public_bucket = true
 
                     writeFileSync(
                         'config.json',
@@ -109,7 +112,13 @@ function createWidget(logger, api, settings, widgetDefaults) {
 
 function createBucket(logger, api, settings) {
     const bucket = {
-        type: 'public'
+        type: 'shared',
+        acl: [
+            {
+                customer_id: '00000000-0000-0000-0000-000000000000',
+                permission: 'ro'
+            }
+        ]
     }
 
     return new Promise((resolve, reject) => {

--- a/toter.js
+++ b/toter.js
@@ -25,8 +25,12 @@ let api, config
 if (!commandsWithoutConfig.includes(command)) {
     const defaultConfig = {
         default: {
-            app_json: {},
-            widget_json: {}
+            app_json: {
+                distribution: ['all']
+            },
+            widget_json: {
+                use_public_widget: true
+            }
         }
     }
 


### PR DESCRIPTION
new distribution and use_public_bucket properties

distribution: ['all'] means that when syncing it will do so across all regions.
the sync only in the current region set distribution: []

Also the bucket needs to have an acl to allow operator customer to read the buckets contents (marketplace reads these and converts into an internal bucket that maintains and syncs across regions).