### PR TITLE
Remove app_id from the list of fields being submitted when performing…

### DIFF
--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -43,9 +43,9 @@ function setup(region, defaults) {
                 } else {
                     rl.question(
                         `Which region do you want to use? (default one is ${
-                            defaults.region
+                        defaults.region
                         }) `,
-                        function(input) {
+                        function (input) {
                             let newRegion = input.trim();
 
                             if (!input) {
@@ -60,22 +60,22 @@ function setup(region, defaults) {
                 }
             },
             title: callback => {
-                rl.question('App/Widget name (en): ', function(input) {
+                rl.question('App/Widget name (en): ', function (input) {
                     callback(null, input);
                 });
             },
             description: callback => {
-                rl.question('App/Widget description: (en): ', function(input) {
+                rl.question('App/Widget description: (en): ', function (input) {
                     callback(null, input);
                 });
             },
             titleJa: callback => {
-                rl.question('App/Widget name (ja): ', function(input) {
+                rl.question('App/Widget name (ja): ', function (input) {
                     callback(null, input);
                 });
             },
             descriptionJa: callback => {
-                rl.question('App/Widget description (ja): ', function(input) {
+                rl.question('App/Widget description (ja): ', function (input) {
                     callback(null, input);
                 });
             },
@@ -84,7 +84,7 @@ function setup(region, defaults) {
                     `Widget deployment location (pick one or many separated by comma) [${availableRegions.join(
                         ','
                     )}]: `,
-                    function(input) {
+                    function (input) {
                         input = input.replace(/(\s|\n|\t|\r)/g, '') || 'all';
 
                         // using a Set here to avoid duplicate region entries
@@ -294,16 +294,17 @@ function createBucketEntry(logger, api, settings) {
 function uploadWidget(logger, api, settings, defaults) {
     let widgetSettings = Object.assign({}, settings.widget);
 
-    // widget id should not be passed into the payload
+    // widget id and app_id should not be passed into the payload
     // due to error key 'id' is invalid to update
     delete widgetSettings.id;
+    delete widgetSettings.app_id;
 
     const widget = Object.assign(defaults.widget, widgetSettings, {
         type: 'marketplace',
         // the bucket was created with using the widget's id as name
         source: `/cmp/api/storage/buckets/${settings.widget.id}/${
             defaults.entry
-        }`
+            }`
     });
 
     return new Promise((resolve, reject) =>

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -1,7 +1,7 @@
-const argv = require('minimist')(process.argv.slice(2));
-const stripFields = require('./../utils/strip-fields');
-const getFile = require('../utils/get-file');
-const isEmpty = require('../utils/empty-file');
+const argv = require("minimist")(process.argv.slice(2));
+const stripFields = require("./../utils/strip-fields");
+const getFile = require("../utils/get-file");
+const isEmpty = require("../utils/empty-file");
 
 module.exports = update;
 
@@ -14,147 +14,144 @@ module.exports = update;
  * @param  {string} region region to filter the configuration file
  */
 function update(api, config, region, defaults) {
-    const hasWidgetId =
-        config[region].widget_json && config[region].widget_json.id;
-    if (!hasWidgetId) {
-        this.logger.error('Please run setup first - widget has no ID');
-        process.exit(1);
-    }
+  const hasWidgetId =
+    config[region].widget_json && config[region].widget_json.id;
+  if (!hasWidgetId) {
+    this.logger.error("Please run setup first - widget has no ID");
+    process.exit(1);
+  }
 
-    const schema = getFile(defaults.schemaPath);
+  const schema = getFile(defaults.schemaPath);
 
-    if (schema && !isEmpty(schema)) {
-        config[region].widget_json.schema = schema.schema;
-    }
+  if (schema && !isEmpty(schema)) {
+    config[region].widget_json.schema = schema.schema;
+  }
 
-    let app = config[region].app_json;
-    let widget = config[region].widget_json;
+  let app = config[region].app_json;
+  let widget = config[region].widget_json;
 
-    return Promise.resolve()
-        .then(() => updateApp(this.logger, api, app))
-        .then(settings =>
-            updateWidget(this.logger, api, settings, widget, defaults)
-        )
-        .then(settings => updateBucket(this.logger, api, settings))
-        .then(() => (argv.f || argv.force) && this.onForce())
-        .catch(err => {
-            this.logger.error(
-                `Unable to update widget: ${JSON.stringify(err)}`
-            );
-            process.exit(1);
-        });
+  return Promise.resolve()
+    .then(() => updateApp(this.logger, api, app))
+    .then(settings =>
+      updateWidget(this.logger, api, settings, widget, defaults)
+    )
+    .then(settings => updateBucket(this.logger, api, settings))
+    .then(() => (argv.f || argv.force) && this.onForce())
+    .catch(err => {
+      this.logger.error(`Unable to update widget: ${JSON.stringify(err)}`);
+      process.exit(1);
+    });
 }
 
 function updateApp(logger, api, app) {
-    return new Promise((resolve, reject) => {
-        const { id, origin } = app;
-        delete app.id;
-        delete app.origin;
+  return new Promise((resolve, reject) => {
+    const { id, origin } = app;
+    delete app.id;
+    delete app.origin;
 
-        return api(`/api/apps/${id}`, app, 'patch')
-            .then(res => {
-                logger.debug(res);
-                logger.info('App patched successfully');
+    return api(`/api/apps/${id}`, app, "patch")
+      .then(res => {
+        logger.debug(res);
+        logger.info("App patched successfully");
 
-                app.id = id;
-                app.origin = origin;
+        app.id = id;
+        app.origin = origin;
 
-                resolve({ app: stripFields(res) });
-            })
-            .catch(err => reject(err));
-    });
+        resolve({ app: stripFields(res) });
+      })
+      .catch(err => reject(err));
+  });
 }
 
 function updateWidget(logger, api, settings, widget, defaults) {
-    return new Promise((resolve, reject) => {
-        const id = widget.id;
+  return new Promise((resolve, reject) => {
+    const id = widget.id;
 
-        // widget id should not be passed into the payload
-        // due to error key 'id' is invalid to update
-        delete widget.id;
+    // widget id should not be passed into the payload
+    // due to error key 'id' is invalid to update
+    delete widget.id;
+    delete widget.app_id;
 
-        widget = Object.assign(defaults.widget, widget, {
-            type: 'marketplace',
-            // the bucket was created with using the widget's id as name
-            source: `/cmp/api/storage/buckets/${id}/${defaults.entry}`
-        });
-
-        logger.debug(
-            `Uploading widget with following configuration: ${widget}`
-        );
-        return api(`/api/apps/widgets/${id}`, widget, 'put')
-            .then(res => {
-                logger.debug(res);
-                logger.info('Widget config updated successfully');
-                widget.id = id;
-                resolve({
-                    app: settings.app_json,
-                    widget: widget
-                });
-            })
-            .catch(err => reject(err));
+    widget = Object.assign(defaults.widget, widget, {
+      type: "marketplace",
+      // the bucket was created with using the widget's id as name
+      source: `/cmp/api/storage/buckets/${id}/${defaults.entry}`
     });
+
+    logger.debug(`Uploading widget with following configuration: ${widget}`);
+    return api(`/api/apps/widgets/${id}`, widget, "put")
+      .then(res => {
+        logger.debug(res);
+        logger.info("Widget config updated successfully");
+        widget.id = id;
+        resolve({
+          app: settings.app_json,
+          widget: widget
+        });
+      })
+      .catch(err => reject(err));
+  });
 }
 
 function updateBucket(logger, api, settings) {
-    const id = settings.widget.id;
-    return deleteBucket(logger, api, id)
-        .then(() => createBucket(logger, api, settings, id))
-        .then(() => createBucketEntry(logger, api, settings, id))
-        .then(() => api(`/api/storage/archive/${id}`, false, 'put', 'x-tgz'))
-        .catch(err => reject(err));
+  const id = settings.widget.id;
+  return deleteBucket(logger, api, id)
+    .then(() => createBucket(logger, api, settings, id))
+    .then(() => createBucketEntry(logger, api, settings, id))
+    .then(() => api(`/api/storage/archive/${id}`, false, "put", "x-tgz"))
+    .catch(err => reject(err));
 }
 
 function deleteBucket(logger, api, id) {
-    return new Promise((resolve, reject) => {
-        api(`/api/storage/buckets/${id}?force=true`, false, 'delete')
-            .then(() => {
-                logger.info('Deleted bucket');
-                resolve();
-            })
-            .catch(err => reject(err));
-    });
+  return new Promise((resolve, reject) => {
+    api(`/api/storage/buckets/${id}?force=true`, false, "delete")
+      .then(() => {
+        logger.info("Deleted bucket");
+        resolve();
+      })
+      .catch(err => reject(err));
+  });
 }
 
 function createBucket(logger, api, settings, id) {
-    const bucket = {
-        type: 'shared',
-        acl: [
-            {
-                customer_id: '00000000-0000-0000-0000-000000000000',
-                permission: 'ro'
-            }
-        ]
-    };
+  const bucket = {
+    type: "shared",
+    acl: [
+      {
+        customer_id: "00000000-0000-0000-0000-000000000000",
+        permission: "ro"
+      }
+    ]
+  };
 
-    return new Promise((resolve, reject) => {
-        api(`/api/storage/buckets/${id}`, bucket, 'put')
-            .then(res => {
-                logger.info('Created bucket');
-                logger.debug(res);
-                resolve({
-                    app: settings.app,
-                    widget: settings.widget
-                });
-            })
-            .catch(err => reject(err));
-    });
+  return new Promise((resolve, reject) => {
+    api(`/api/storage/buckets/${id}`, bucket, "put")
+      .then(res => {
+        logger.info("Created bucket");
+        logger.debug(res);
+        resolve({
+          app: settings.app,
+          widget: settings.widget
+        });
+      })
+      .catch(err => reject(err));
+  });
 }
 function createBucketEntry(logger, api, settings, id) {
-    const bucket = {
-        type: 'public'
-    };
+  const bucket = {
+    type: "public"
+  };
 
-    return new Promise((resolve, reject) => {
-        api(`/api/storage/buckets/${id}/entry`, bucket, 'put')
-            .then(res => {
-                logger.info('Created bucket entry');
-                logger.debug(res);
-                resolve({
-                    app: settings.app,
-                    widget: settings.widget
-                });
-            })
-            .catch(err => reject(err));
-    });
+  return new Promise((resolve, reject) => {
+    api(`/api/storage/buckets/${id}/entry`, bucket, "put")
+      .then(res => {
+        logger.info("Created bucket entry");
+        logger.debug(res);
+        resolve({
+          app: settings.app,
+          widget: settings.widget
+        });
+      })
+      .catch(err => reject(err));
+  });
 }


### PR DESCRIPTION
Plaza is now returning `app_id` in the response payload of POST /apps/widgets, however that is not a valid field for PUT /apps/widgets. This simply removes that field from the payload being submitted to PUT /apps/widgets in toter setup. 